### PR TITLE
Add allowed_modules for DiscouragedModules and PreferredAlternatives

### DIFF
--- a/lib/Perl/Critic/Policy/Community/DiscouragedModules.pm
+++ b/lib/Perl/Critic/Policy/Community/DiscouragedModules.pm
@@ -8,7 +8,15 @@ use parent 'Perl::Critic::Policy';
 
 our $VERSION = 'v1.0.1';
 
-sub supported_parameters { () }
+sub supported_parameters {
+	(
+		{
+			name            => 'allowed_modules',
+			description     => 'Modules that you want to allow, despite being discouraged.',
+			behavior        => 'string list',
+		},
+	)
+}
 sub default_severity { $SEVERITY_HIGH }
 sub default_themes { 'community' }
 sub applies_to { 'PPI::Statement::Include' }
@@ -40,7 +48,7 @@ sub _violation {
 
 sub violates {
 	my ($self, $elem) = @_;
-	return () unless defined $elem->module and exists $modules{$elem->module};
+	return () unless defined $elem->module and exists $modules{$elem->module} and not exists $self->{_allowed_modules}{$elem->module};
 	return $self->_violation($elem->module, $elem);
 }
 
@@ -164,7 +172,14 @@ This policy is part of L<Perl::Critic::Community>.
 
 =head1 CONFIGURATION
 
-This policy is not configurable except for the standard options.
+Occasionally you may find yourself needing to use one of these discouraged
+modules, and do not want the warnings.  You can do so by putting something like
+the following in a F<.perlcriticrc> file like this:
+
+    [Community::DiscouragedModules]
+    allowed_modules = FindBin Any::Moose
+
+The same option is offered for L<Perl::Critic::Policy::Community::PreferredAlternatives>.
 
 =head1 AUTHOR
 

--- a/lib/Perl/Critic/Policy/Community/PreferredAlternatives.pm
+++ b/lib/Perl/Critic/Policy/Community/PreferredAlternatives.pm
@@ -8,7 +8,15 @@ use parent 'Perl::Critic::Policy';
 
 our $VERSION = 'v1.0.1';
 
-sub supported_parameters { () }
+sub supported_parameters {
+	(
+		{
+			name            => 'allowed_modules',
+			description     => 'Modules that you want to allow, despite there being a preferred alternative.',
+			behavior        => 'string list',
+		},
+	)
+}
 sub default_severity { $SEVERITY_LOW }
 sub default_themes { 'community' }
 sub applies_to { 'PPI::Statement::Include' }
@@ -30,7 +38,7 @@ sub _violation {
 
 sub violates {
 	my ($self, $elem) = @_;
-	return () unless defined $elem->module and exists $modules{$elem->module};
+	return () unless defined $elem->module and exists $modules{$elem->module} and not exists $self->{_allowed_modules}{$elem->module};
 	return $self->_violation($elem->module, $elem);
 }
 
@@ -85,7 +93,14 @@ This policy is part of L<Perl::Critic::Community>.
 
 =head1 CONFIGURATION
 
-This policy is not configurable except for the standard options.
+Occasionally you may find yourself needing to use one of these non-preferred
+modules, and do not want the warnings.  You can do so by putting something like
+the following in a F<.perlcriticrc> file like this:
+
+    [Community::PreferredAlternatives]
+    allowed_modules = Getopt::Std JSON
+
+The same option is offered for L<Perl::Critic::Policy::Community::DiscouragedModules>.
 
 =head1 AUTHOR
 

--- a/t/Community/DiscouragedModules.run
+++ b/t/Community/DiscouragedModules.run
@@ -60,3 +60,21 @@ use JSON::XS;
 use Net::IRC;
 use Switch;
 use XML::Simple;
+
+## name Allowed BadModules
+## parms { allowed_modules => 'AnyEvent FindBin JSON::XS' };
+## failures 0
+## cut
+
+use AnyEvent;
+use FindBin;
+use JSON::XS;
+
+## name Allowed BadModules failing
+## parms { allowed_modules => 'AnyEvent FindBin JSON::XS' };
+## failures 3
+## cut
+
+use Any::Moose;
+use CGI;
+use IO::Socket::INET6;

--- a/t/Community/PreferredAlternatives.run
+++ b/t/Community/PreferredAlternatives.run
@@ -24,3 +24,20 @@ use JSON;
 use List::MoreUtils;
 use Mouse;
 use Readonly;
+
+## name Allowed BadModules
+## parms { allowed_modules => 'Getopt::Std JSON' };
+## failures 0
+## cut
+
+use Getopt::Std;
+use JSON;
+
+## name Allowed BadModules failing
+## parms { allowed_modules => 'Getopt::Std JSON' };
+## failures 3
+## cut
+
+use List::MoreUtils;
+use Mouse;
+use Readonly;


### PR DESCRIPTION
Adds the `allowed_modules` configuration to list specific modules you don't want to receive errors for.

Closes #42.