### PR TITLE
Community::StrictWarnings: Don't trigger violation with a use declaration >=5.36

### DIFF
--- a/lib/Perl/Critic/Policy/Community/StrictWarnings.pm
+++ b/lib/Perl/Critic/Policy/Community/StrictWarnings.pm
@@ -53,6 +53,7 @@ sub violates {
 		if ($include->type//'' eq 'use') {
 			$has_strict = 1 if $include->version and version->parse($include->version) >= version->parse('v5.12');
 			$has_strict = 1 if defined $include->module and exists $strict_importers{$include->module};
+			$has_warnings = 1 if $include->version and version->parse($include->version) >= version->parse('v5.36');
 			$has_warnings = 1 if defined $include->module and exists $warnings_importers{$include->module};
 		}
 		return () if $has_strict and $has_warnings;
@@ -75,7 +76,8 @@ misspellings, scoping issues, and performing operations on undefined values.
 Warnings can also alert you to deprecated or experimental functionality. The
 pragmas may either be explicitly imported with C<use>, or indirectly through a
 number of importer modules such as L<Moose> or L<strictures>. L<strict> is also
-enabled automatically with a C<use> declaration of perl version 5.12 or higher.
+enabled automatically with a C<use> declaration of perl version 5.12 or higher,
+as is L<warnings> with a C<use> declaration of 5.36 or higher.
 
   use strict;
   use warnings;
@@ -84,6 +86,8 @@ enabled automatically with a C<use> declaration of perl version 5.12 or higher.
 
   use 5.012;
   use warnings;
+
+  use 5.036;
 
 This policy is similar to the core policies
 L<Perl::Critic::Policy::TestingAndDebugging::RequireUseStrict> and

--- a/t/Community/StrictWarnings.run
+++ b/t/Community/StrictWarnings.run
@@ -77,6 +77,42 @@ use warnings;
 use 5.10.1;
 use warnings;
 
+## name VersionWarnings1
+## failures 0
+## cut
+
+use 5.036;
+
+## name VersionWarnings2
+## failures 0
+## cut
+
+use v5.36;
+
+## name VersionWarnings3
+## failures 0
+## cut
+
+use 5.36.0;
+
+## name VersionWarnings4
+## failures 1
+## cut
+
+use 5.034001;
+
+## name VersionWarnings5
+## failures 1
+## cut
+
+use v5.34;
+
+## name VersionWarnings6
+## failures 1
+## cut
+
+use 5.34.1;
+
 ## name CustomImporter
 ## failures 0
 ## parms { extra_importers => 'MyApp::Base' }


### PR DESCRIPTION
As of the latest stable Perl release `use v5.36`, `use 5.036`, etc. automatically enable warnings. This PR updates the Community::StrictWarnings policy such that a lack of an explicit `use warnings` won't trigger a violation