### PR TITLE
GitHub CI Pipeline

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,86 @@
+name: 'Build & Test'
+
+on:
+  push:
+    branches:
+      - "*"
+    tags-ignore:
+      - "*"
+  pull_request:
+
+jobs:
+
+###
+### Fast Test on System Perl
+###
+
+  ubuntu-latest:
+    runs-on: ubuntu-latest
+
+    env:
+      PERL_USE_UNSAFE_INC: 0
+      AUTHOR_TESTING: 1
+      AUTOMATED_TESTING: 1
+      RELEASE_TESTING: 1
+      PERL_CARTON_PATH: $GITHUB_WORKSPACE/local
+
+    steps:
+      - uses: actions/checkout@v4
+      - run: perl -V
+      - name: install deps using cpanm
+        uses: perl-actions/install-with-cpanm@v1
+        with:
+          sudo: false
+          args: --sudo --installdeps .
+      - run: perl Build.PL
+      - run: ./Build
+      - run: ./Build test
+
+###
+### linux testing multiple Perl versions
+###
+
+  perl-versions:
+    runs-on: ubuntu-latest
+    name: List Perl versions
+    outputs:
+      perl-versions: ${{ steps.action.outputs.perl-versions }}
+    steps:
+      - id: action
+        uses: perl-actions/perl-versions@v1
+        with:
+          since-perl: v5.10
+          with-devel: true
+
+  linux:
+    runs-on: ubuntu-latest
+    name: "perl ${{ matrix.perl-version }}"
+
+    needs:
+      - ubuntu-latest
+      - perl-versions
+
+    strategy:
+      fail-fast: false
+      matrix:
+        perl-version: ${{ fromJson (needs.perl-versions.outputs.perl-versions) }}
+
+    container:
+      image: perldocker/perl-tester:${{ matrix.perl-version }}
+
+    steps:
+      - uses: actions/checkout@v4
+      - run: perl -V
+      - name: install deps using cpanm
+        uses: perl-actions/install-with-cpanm@v1
+        with:
+          sudo: false
+          args: -v --installdeps .
+      - run: perl Build.PL
+      - run: ./Build
+      - run: ./Build test
+        env:
+          AUTHOR_TESTING: 1
+          AUTOMATED_TESTING: 1
+          RELEASE_TESTING: 1
+

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ inc/
 Build
 !Build/
 Build.bat
+.DS_Store
 .last_cover_stats
 /Makefile
 /Makefile.old


### PR DESCRIPTION
I know the the repo is using travis CI but this current pipeline is automatically detecting new releases of Perl versions and can see it as an addition of the existing pipeline

view run output from https://github.com/atoomic/Perl-Critic-Community/actions/runs/11885981561